### PR TITLE
:sparkles: Playground: Use codesnap.wasm to render user's code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@heroui/react": "2.8.0-beta.2",
         "@monaco-editor/react": "^4.7.0",
         "@vscode/vscode-languagedetection": "^1.0.22",
-        "codesnap.wasm": "^0.12.6",
+        "codesnap.wasm": "^0.12.9",
         "downloadjs": "^1.4.7",
         "framer-motion": "^12.9.7",
         "fumadocs-core": "15.2.12",
@@ -5917,9 +5917,10 @@
       }
     },
     "node_modules/codesnap.wasm": {
-      "version": "0.12.6",
-      "resolved": "https://registry.npmjs.org/codesnap.wasm/-/codesnap.wasm-0.12.6.tgz",
-      "integrity": "sha512-R6a92K+Ea4EBJPhMcjlHUQsbzSvDRNcaD3VviWCKZHsoABz5EzSlH0aanu2AgNZqqY/aitf9jsNVP1cAyCIaYg=="
+      "version": "0.12.9",
+      "resolved": "https://registry.npmjs.org/codesnap.wasm/-/codesnap.wasm-0.12.9.tgz",
+      "integrity": "sha512-RO7GOhkBqszj23Y1ZvUnvWZJzYvYqgtiNq1uEALkOZmXJzCK0U8SUS0PmLtlDTwYkPz3HYgPjg7Lq6L+XyjA8Q==",
+      "license": "MIT"
     },
     "node_modules/collapse-white-space": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@heroui/react": "2.8.0-beta.2",
     "@monaco-editor/react": "^4.7.0",
     "@vscode/vscode-languagedetection": "^1.0.22",
-    "codesnap.wasm": "^0.12.6",
+    "codesnap.wasm": "^0.12.9",
     "downloadjs": "^1.4.7",
     "framer-motion": "^12.9.7",
     "fumadocs-core": "15.2.12",

--- a/src/app/(home)/layout.tsx
+++ b/src/app/(home)/layout.tsx
@@ -12,6 +12,10 @@ export default function Layout({ children }: { children: ReactNode }) {
           url: "/docs/library",
           active: "nested-url",
         },
+        {
+          text: "Playground",
+          url: "/playground",
+        },
       ]}
     >
       {children}

--- a/src/app/global.css
+++ b/src/app/global.css
@@ -78,3 +78,7 @@
     background-position: 0% 50%;
   }
 }
+
+.monospace {
+  font-family: monospace;
+}

--- a/src/app/playground/layout.tsx
+++ b/src/app/playground/layout.tsx
@@ -1,0 +1,3 @@
+import Layout from "../(home)/layout";
+
+export default Layout

--- a/src/app/playground/page.tsx
+++ b/src/app/playground/page.tsx
@@ -1,0 +1,87 @@
+"use client"
+
+import { useEffect, useState } from "react";
+import init, { take_snapshot } from "codesnap.wasm";
+
+export default function Playground() {
+    const [loaded, setLoaded] = useState(false)
+    const [code, setCode] = useState('print "Hello, World!"')
+    const [lang, setLang] = useState('python')
+    const [imgUrl, setImgUrl] = useState('')
+
+    // TODO: Fetch supported languages from the wasm module, need to consider "before init" behavior
+    const supportedLanguages = [
+        {code: 'python', name: 'Python'},
+        {code: 'rust', name: 'Rust'},
+        {code: 'javascript', name: 'JavaScript'},
+        {code: 'typescript', name: 'TypeScript'},
+        {code: 'java', name: 'Java'},
+        {code: 'c', name: 'C'},
+        {code: 'cpp', name: 'C++'},
+        {code: 'csharp', name: 'C#'},
+        {code: 'go', name: 'Go'},
+        {code: 'ruby', name: 'Ruby'},
+        {code: 'php', name: 'PHP'},
+    ];
+
+    init().then(() => { setLoaded(true) })
+    useEffect(() => {
+        if (!loaded) {
+            return;
+        }
+
+        const generateImageUrlTimeout = setTimeout(() => {
+            const snapshot = take_snapshot(code, lang)
+             // TODO: This freezes the UI for a few seconds, defer to a worker ?
+            const imageSnapshot = snapshot.create_image_snapshot();
+            const { data } = imageSnapshot.png_data();
+            const blob = new Blob([data], { type: "image/png" });
+            setImgUrl(URL.createObjectURL(blob));
+        }, 500)
+
+        return () => clearTimeout(generateImageUrlTimeout)
+    }, [code, lang, loaded])
+
+    return (
+        <div className="container mx-auto mt-8">
+            <h1 className="text-3xl font-bold mb-8 text-center dark:text-white">Playground</h1>
+            <div className="flex flex-col md:flex-row gap-8">
+                {/* Left Panel: Code Input */}
+                <div className="flex-1 bg-gray-50 dark:bg-gray-800 rounded-lg shadow p-6">
+                    <div className="flex items-center mb-2">
+                        <label className="block font-semibold mr-3 dark:text-gray-200">Language</label>
+                        <select
+                            value={lang}
+                            onChange={(e) => setLang(e.target.value)}
+                            className="p-2 rounded border border-gray-300 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-400"
+                        >
+                            {supportedLanguages.map((language) => (
+                                <option key={language.code} value={language.code}>
+                                    {language.name}
+                                </option>
+                            ))}
+                        </select>
+                    </div>
+                    <textarea
+                        className="w-full min-h-[300px] font-mono text-base rounded border border-gray-300 dark:border-gray-700 p-3 bg-white dark:bg-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-400"
+                        onChange={(e) => setCode(e.target.value)}
+                        value={code}
+                    />
+                </div>
+                {/* Right Panel: Image Output */}
+                <div className="flex-1 bg-white dark:bg-gray-900 rounded-lg shadow p-6 flex flex-col items-center justify-center min-h-[350px]">
+                    <h2 className="text-xl font-semibold mb-4 dark:text-gray-200">Preview</h2>
+                    {imgUrl ? (
+                        <img
+                            src={imgUrl}
+                            alt="Code snapshot"
+                            className="max-w-full max-h-[400px] rounded border border-gray-200 dark:border-gray-700 shadow"
+                        />
+                    ) : (
+                        <p className="text-gray-500 dark:text-gray-400">Rendering…</p>
+                    )}
+                </div>
+            </div>
+        </div>
+    )
+}


### PR DESCRIPTION
Fixes https://github.com/codesnap-rs/codesnap/issues/44

Edit: I just noticed that it was possible to use codesnap on the homepage, maybe I should just add a language selector there?

![image](https://github.com/user-attachments/assets/f9f722ee-cca7-41ae-b6da-260f29ab0e99)
![image](https://github.com/user-attachments/assets/3ad158c4-1470-4f22-87f8-1d17d3d05fdf)
